### PR TITLE
Force ~> 1.3.1 of omniauth-oauth2

### DIFF
--- a/omniauth-money_bird.gemspec
+++ b/omniauth-money_bird.gemspec
@@ -5,7 +5,7 @@ require "omniauth/money_bird/version"
 Gem::Specification.new do |gem|
   gem.add_dependency "oauth2",     "~> 1.0"
   gem.add_dependency 'omniauth', '~> 1.0'
-  gem.add_dependency 'omniauth-oauth2', '~> 1.0'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.3.1'
 
   gem.add_development_dependency "bundler", "~> 1.0"
 


### PR DESCRIPTION
Moneybird has the same [incompatability as listed here](https://github.com/intridea/omniauth-oauth2/issues/81) and the easiest fix is to just not use `1.4.0` of `omniauth-oauth2`.